### PR TITLE
Specify the PyMySQL version we can work with.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'umysql',
-    'pymysql',
+    'pymysql<0.6',
 ]
 
 setup(


### PR DESCRIPTION
https://github.com/PyMySQL/PyMySQL/commit/e8ae4ce8812392c993d5029a5ccbf5667310b3fa
Method Cursor.errorhandler has been removed in the PyMySQL latest version. So this is the easiest way to work around.
